### PR TITLE
use relatives paths for fonts

### DIFF
--- a/iconfont/material-icons.css
+++ b/iconfont/material-icons.css
@@ -2,9 +2,9 @@
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
-  src: url("MaterialIcons-Regular.eot");
+  src: url("./MaterialIcons-Regular.eot");
   /* For IE6-8 */
-  src: local("Material Icons"), local("MaterialIcons-Regular"), url("MaterialIcons-Regular.woff2") format("woff2"), url("MaterialIcons-Regular.woff") format("woff"), url("MaterialIcons-Regular.ttf") format("truetype");
+  src: local("Material Icons"), local("MaterialIcons-Regular"), url("./MaterialIcons-Regular.woff2") format("woff2"), url("./MaterialIcons-Regular.woff") format("woff"), url("./MaterialIcons-Regular.ttf") format("truetype");
 }
 
 .material-icons {


### PR DESCRIPTION
This allows Material Icons font to be imported with webpack (like in [CRA](https://github.com/facebook/create-react-app)) with no need to copy the font to public dir (just `import 'material-icons/iconfont/material-icons.css';`).