### PR TITLE
Add `font-display` descriptor to font face at-rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $material-icons-font-path: '' !default;
 $material-icons-font-name: 'MaterialIcons-Regular' !default;
 $material-icons-font-size: 24px !default;
 $material-icons-font-family: 'Material Icons' !default;
+$material-icons-font-display: block !default;
 ```
 
 Available Sass mixins:

--- a/iconfont/mixins.scss
+++ b/iconfont/mixins.scss
@@ -21,7 +21,8 @@
   $font-family: $material-icons-font-family,
   $font-name: $material-icons-font-name,
   $otf: false,
-  $font-path: $material-icons-font-path
+  $font-path: $material-icons-font-path,
+  $font-display: $material-icons-font-display
 ) {
   $font-file: $font-path + $font-name;
 
@@ -29,6 +30,7 @@
     font-family: $font-family;
     font-style: normal;
     font-weight: 400;
+    font-display: $font-display;
     src: url('#{$font-file}.eot'); /* For IE6-8 */
     src: local($font-family), local($font-name),
       url('#{$font-file}.woff2') format('woff2'),

--- a/iconfont/variables.scss
+++ b/iconfont/variables.scss
@@ -4,3 +4,4 @@ $material-icons-font-path: '' !default;
 $material-icons-font-name: 'MaterialIcons-Regular' !default;
 $material-icons-font-size: 24px !default;
 $material-icons-font-family: 'Material Icons' !default;
+$material-icons-font-display: block !default;


### PR DESCRIPTION
The `font-display` descriptor [determines](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) how a font face is displayed based on whether and when it is downloaded and ready to use. The `block` value instructs the browser to briefly hide the text until the font has fully downloaded. More accurately, the browser draws the text with an invisible placeholder then swaps it with the custom font face as soon as it loads.