### PR TITLE
Automatically generate MaterialIcon type from version metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,17 +4,21 @@
   "description": "Latest icon fonts and CSS for self-hosting material design icons.",
   "browser": "iconfont/material-icons.css",
   "sass": "iconfont/material-icons.scss",
+  "types": "index.d.ts",
   "files": [
+    "index.d.ts",
     "_data/versions.json",
     "css/*.{css,scss}",
     "iconfont/*.{css,scss,woff,woff2}"
   ],
   "scripts": {
     "check": "npm run download:metadata -- --status --dry-run",
-    "update": "npm run download && npm run build",
+    "update": "npm run download && npm run generate && npm run build",
     "download": "npm run download:font && npm run download:metadata",
     "download:font": "npx @material-design-icons/scripts download font --to iconfont",
     "download:metadata": "npx @material-design-icons/scripts download metadata",
+    "generate": "npm run generate:types",
+    "generate:types": "npx @material-design-icons/scripts generate types --in ./",
     "build": "npm run build:codepoints && npm run build:css && npm run build:css:min",
     "build:codepoints": "node scripts/codepoints.js",
     "build:css": "sass --no-source-map --no-error-css css iconfont",


### PR DESCRIPTION
Depends on marella/material-design-icons#12

Automatically generate and export `MaterialIcon` type for type checking and autocomplete of class names.